### PR TITLE
Fix ESM module resolution for Node.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import "dotenv/config";
 
-import { logger } from "./utils/logger";
-import { initializeSDK, closeSDK } from "./utils/sdk";
-import { registerAllTools } from "./tools";
+import { logger } from "./utils/logger.js";
+import { initializeSDK, closeSDK } from "./utils/sdk.js";
+import { registerAllTools } from "./tools/index.js";
 
 // Set log level from environment
 if (process.env.LOG_LEVEL) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -8,7 +8,7 @@ import {
   getAllContacts,
   searchContacts,
   findContactByPhone,
-} from "./utils/contacts";
+} from "./utils/contacts.js";
 
 const sdk = new IMessageSDK({
   debug: false,

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getSDK } from "../utils/sdk";
-import { logger } from "../utils/logger";
+import { getSDK } from "../utils/sdk.js";
+import { logger } from "../utils/logger.js";
 
 export function registerAttachmentTools(server: McpServer) {
   // Get messages with attachments

--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getSDK } from "../utils/sdk";
-import { logger } from "../utils/logger";
-import { searchContacts, getAllContacts } from "../utils/contacts";
+import { getSDK } from "../utils/sdk.js";
+import { logger } from "../utils/logger.js";
+import { searchContacts, getAllContacts } from "../utils/contacts.js";
 
 export function registerConversationTools(server: McpServer) {
   // Find contact by name - searches both iMessage chats AND macOS Contacts

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerMessageTools } from "./messages";
-import { registerConversationTools } from "./conversations";
-import { registerAttachmentTools } from "./attachments";
-import { logger } from "../utils/logger";
+import { registerMessageTools } from "./messages.js";
+import { registerConversationTools } from "./conversations.js";
+import { registerAttachmentTools } from "./attachments.js";
+import { logger } from "../utils/logger.js";
 
 export function registerAllTools(server: McpServer) {
   logger.info("Registering MCP tools...");

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getSDK } from "../utils/sdk";
-import { logger } from "../utils/logger";
+import { getSDK } from "../utils/sdk.js";
+import { logger } from "../utils/logger.js";
 
 export function registerMessageTools(server: McpServer) {
   // Get messages with filtering

--- a/src/utils/contacts.ts
+++ b/src/utils/contacts.ts
@@ -7,7 +7,7 @@ import Database from "better-sqlite3";
 import { existsSync, readdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 export interface Contact {
   id: number;

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -1,5 +1,5 @@
 import { IMessageSDK } from "@photon-ai/imessage-kit";
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 let sdk: IMessageSDK | null = null;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary
- Change tsconfig `module`/`moduleResolution` from `ESNext`/`Bundler` to `NodeNext`
- Add `.js` extensions to all local imports across 8 source files

## Problem
Running `node dist/index.js` fails with `ERR_MODULE_NOT_FOUND` because Node.js ESM requires explicit `.js` extensions for relative imports. The `Bundler` moduleResolution setting was designed for bundlers (Vite, webpack), not direct Node.js execution.

## Test plan
- [x] Run `pnpm build` - compiles without errors
- [x] Run `node dist/index.js` - server starts successfully

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)